### PR TITLE
keep showing progress bar when percent value is/beyond 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ color     | string | rainbow | keyword, hexadecimal, rgb, or hsla
 percent   | number | 0       | 0-100
 height    | number | 2       | pixels
 hideDelay | number | .4      | seconds
+showProgressOnHundred | boolean | falsy      | seconds
 speed     | number | .4      | seconds
 style     | object | {}      |
 

--- a/src/react-progress.js
+++ b/src/react-progress.js
@@ -16,13 +16,15 @@ export default (props) => {
     ...props
   };
 
-  let containerStyle = {
-    opacity: props.percent < 100 ? 1 : 0,
-    WebkitTransition: `${props.speed}s opacity`,
-    transition: `${props.speed}s opacity`,
-    WebkitTransitionDelay: `${props.percent < 100 ? 0 : props.hideDelay}s`,
-    transitionDelay: `${props.percent < 100 ? 0 : props.hideDelay}s`
-  };
+  let containerStyle = props.showProgressOnHundred
+    ? {}
+    : {
+        opacity: props.percent < 100 ? 1 : 0,
+        WebkitTransition: `${props.speed}s opacity`,
+        transition: `${props.speed}s opacity`,
+        WebkitTransitionDelay: `${props.percent < 100 ? 0 : props.hideDelay}s`,
+        transitionDelay: `${props.percent < 100 ? 0 : props.hideDelay}s`
+      };
 
   let barStyle = {
     display: 'inline-block',


### PR DESCRIPTION
Progress bar hides on `percent >= 100`. Added a new prop `showProgressOnHundred` to override the behavior.